### PR TITLE
feat: input 컴포넌트 구현 및 스토리북 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,81 +1,78 @@
-import { Button } from './components/button/Button';
-import './index.css';
+import { Input } from './components/input/Input';
 
 export default function App() {
-  const variants = [
-    'primary',
-    'secondary',
-    'outline',
-    'ghost',
-    'destrctive',
-  ] as const;
+  const states = ['default', 'disabled', 'error'] as const;
   const sizes = ['mini', 'small', 'regular', 'large'] as const;
-  const states = ['default', 'disabled'] as const;
 
   return (
     <div className='w-screen min-h-screen bg-gray-50 p-8'>
-      <div className='max-w-6xl mx-auto'>
-        <h1 className='text-3xl font-bold text-center mb-8 text-gray-800'>
-          Button Design System
+      <div className='max-w-4xl mx-auto'>
+        <h1 className='text-3xl font-bold text-center mb-8 text-gray-800 '>
+          Input Design System
         </h1>
         {/* 전체 스타일 */}
-        {variants.map((variant) => (
-          <div key={variant} className='mb-12'>
-            <h2 className='text-2xl font-semibold mb-6 text-gray-700 capitalize border-b pb-2'>
-              {variant} Variant
-            </h2>
-            <div className='grid gap-8'>
-              {states.map((state) => (
-                <div
-                  key={state}
-                  className='bg-white p-6 rounded-lg shadow-sm border'
-                >
-                  <h3 className='text-lg font-medium mb-4 text-gray-600 capitalize'>
-                    {state} State
-                  </h3>
-                  <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6'>
-                    {sizes.map((size) => (
-                      <div
-                        key={size}
-                        className='flex flex-col items-center space-y-3'
-                      >
-                        <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
-                          {size}
-                        </div>
-                        <Button
-                          variant={variant}
-                          size={size}
-                          isDisable={state === 'disabled'}
-                        >
-                          Label
-                        </Button>
-                        <div className='text-xs text-gray-400 text-center'>
-                          {variant} / {size} / {state}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+        <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
+          Empty
+        </h2>
+        <div className='mb-12'>
+          <div className='grid grid-cols-2 gap-6 bg-white p-8 rounded-lg shadow-sm border'>
+            {sizes.map((size) => (
+              <div key={size} className='flex flex-col items-center space-y-3'>
+                <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
+                  {size}
                 </div>
-              ))}
+                <Input size={size} state='default' />
+                <div className='text-xs text-gray-400 text-center'>
+                  {size} / default
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        {states.map((state) => (
+          <div key={state} className='mb-12'>
+            <h2 className='text-2xl font-semibold mb-6 text-gray-700 capitalize border-b pb-2'>
+              {state} State
+            </h2>
+            <div className='bg-white p-6 rounded-lg shadow-sm border'>
+              <div className='grid grid-cols-2 gap-6'>
+                {sizes.map((size) => (
+                  <div
+                    key={size}
+                    className='flex flex-col items-center space-y-3'
+                  >
+                    <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
+                      {size}
+                    </div>
+                    <Input
+                      size={size}
+                      state={state}
+                      placeholder={`${size} ${state}`}
+                    />
+                    <div className='text-xs text-gray-400 text-center'>
+                      {size} / {state}
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         ))}
-        {/* variant 전체 */}
+        {/* state 전체 */}
         <div className='mt-16 bg-white p-8 rounded-lg shadow-sm border'>
           <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
-            한눈에 보기 - Regular Size, Default State
+            한눈에 보기 - Regular Size
           </h2>
           <div className='flex flex-wrap gap-4 justify-center'>
-            {variants.map((variant) => (
-              <div
-                key={variant}
-                className='flex flex-col items-center space-y-2'
-              >
-                <Button variant={variant} size='regular' isDisable={false}>
-                  {variant}
-                </Button>
+            {states.map((state) => (
+              <div key={state} className='flex flex-col items-center space-y-2'>
+                <Input
+                  size='regular'
+                  state={state}
+                  placeholder={`${state} input`}
+                />
                 <span className='text-xs text-gray-500 capitalize'>
-                  {variant}
+                  {state}
                 </span>
               </div>
             ))}
@@ -84,14 +81,16 @@ export default function App() {
         {/* 사이즈 비교 */}
         <div className='mt-8 bg-white p-8 rounded-lg shadow-sm border'>
           <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
-            사이즈 비교 - Primary Variant, Default State
+            사이즈 비교 - Default State
           </h2>
           <div className='flex flex-wrap items-end gap-6 justify-center'>
             {sizes.map((size) => (
               <div key={size} className='flex flex-col items-center space-y-2'>
-                <Button variant='primary' size={size} isDisable={false}>
-                  {size}
-                </Button>
+                <Input
+                  size={size}
+                  state='default'
+                  placeholder={`${size} input`}
+                />
                 <span className='text-xs text-gray-500 capitalize'>{size}</span>
               </div>
             ))}
@@ -100,18 +99,16 @@ export default function App() {
         {/* 상태 비교 */}
         <div className='mt-8 bg-white p-8 rounded-lg shadow-sm border'>
           <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
-            상태 비교 - Primary Variant, Regular Size
+            상태 비교 - Regular Size
           </h2>
-          <div className='flex gap-6 justify-center'>
+          <div className='flex flex-wrap items-end gap-6 justify-center'>
             {states.map((state) => (
               <div key={state} className='flex flex-col items-center space-y-2'>
-                <Button
-                  variant='primary'
+                <Input
                   size='regular'
-                  isDisable={state === 'disabled'}
-                >
-                  {state}
-                </Button>
+                  state={state}
+                  placeholder={`${state} input`}
+                />
                 <span className='text-xs text-gray-500 capitalize'>
                   {state}
                 </span>

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,0 +1,47 @@
+import type { ComponentProps } from 'react';
+
+type InputProps = {
+  size?: 'mini' | 'small' | 'regular' | 'large';
+  state?: 'default' | 'disabled' | 'error';
+  placeholder?: string;
+};
+
+export const Input = ({
+  size = 'regular',
+  state = 'default',
+  placeholder = '',
+  ...props
+}: Omit<ComponentProps<'input'>, 'size'> & InputProps) => {
+  const sizeClass = {
+    mini: 'h-6 px-1.5 py-1 text-xs rounded-sm',
+    small: 'h-8 px-2 py-1.5 text-sm rounded-lg',
+    regular: 'h-9 px-3 py-2 text-base rounded-lg',
+    large: 'h-10 px-4 py-2.5 text-lg rounded-lg',
+  };
+
+  const stateClass = {
+    default: 'border border-neutral-300 focus:ring-neutral-300',
+    error: 'border border-red-500 focus:ring-red-300',
+    disabled: 'border border-neutral-300 opacity-50 cursor-not-allowed',
+  };
+
+  let currentState: 'default' | 'error' | 'disabled' = 'default';
+
+  if (state === 'disabled') currentState = 'disabled';
+  else if (state === 'error') currentState = 'error';
+
+  return (
+    <>
+      <input
+        className={`
+          w-80 bg-white border text-neutral-900 placeholder:text-neutral-500 placeholder:font-normal focus:ring-2 focus:ring-inset focus:outline-none
+          ${sizeClass[size]}
+          ${stateClass[currentState]}
+        `}
+        placeholder={placeholder}
+        disabled={state === 'disabled'}
+        {...props}
+      />
+    </>
+  );
+};

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -2,13 +2,15 @@ import type { ComponentProps } from 'react';
 
 type InputProps = {
   size?: 'mini' | 'small' | 'regular' | 'large';
-  state?: 'default' | 'disabled' | 'error';
+  isDisabled: boolean;
+  isError: boolean;
   placeholder?: string;
 };
 
 export const Input = ({
   size = 'regular',
-  state = 'default',
+  isDisabled = false,
+  isError = false,
   placeholder = '',
   ...props
 }: Omit<ComponentProps<'input'>, 'size'> & InputProps) => {
@@ -25,10 +27,11 @@ export const Input = ({
     disabled: 'border border-neutral-300 opacity-50 cursor-not-allowed',
   };
 
-  let currentState: 'default' | 'error' | 'disabled' = 'default';
+  let state: 'default' | 'error' | 'disabled' = 'default';
 
-  if (state === 'disabled') currentState = 'disabled';
-  else if (state === 'error') currentState = 'error';
+  if (isDisabled) state = 'disabled';
+  else if (isError) state = 'error';
+  else state = 'default';
 
   return (
     <>
@@ -36,10 +39,10 @@ export const Input = ({
         className={`
           w-80 bg-white border text-neutral-900 placeholder:text-neutral-500 placeholder:font-normal focus:ring-2 focus:ring-inset focus:outline-none
           ${sizeClass[size]}
-          ${stateClass[currentState]}
+          ${stateClass[state]}
         `}
         placeholder={placeholder}
-        disabled={state === 'disabled'}
+        disabled={isDisabled}
         {...props}
       />
     </>

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Input } from '../components/input/Input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['mini', 'small', 'regular', 'large'],
+      description: '입력 필드의 크기',
+    },
+    isDisabled: {
+      control: { type: 'boolean' },
+      description: '입력 필드 비활성화 여부',
+    },
+    isError: {
+      control: { type: 'boolean' },
+      description: '입력 필드 에러 상태 여부',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: '플레이스홀더 텍스트',
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'email', 'password', 'number', 'tel', 'url'],
+      description: '입력 필드의 타입',
+    },
+    onChange: {
+      action: 'changed',
+      description: '값 변경 이벤트',
+    },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 원래 _ 붙이면 사이드바에서 안보여야하는데 보임
+export const _Interactive: Story = {
+  args: {
+    size: 'regular',
+    isDisabled: false,
+    isError: false,
+    placeholder: '텍스트를 입력하세요',
+  },
+  parameters: {
+    docs: {
+      primary: true,
+    },
+    // 원래 true로 하면 사이드바에서 안보여야하는데 보임
+    sidebar: {
+      disable: true,
+    },
+  },
+};
+
+export const Default: Story = {
+  args: {
+    size: 'regular',
+    isDisabled: false,
+    isError: false,
+    placeholder: '기본 입력 필드',
+  },
+  argTypes: {
+    isDisabled: {
+      control: false,
+      description: '입력 필드 비활성화 여부 (false로 고정)',
+    },
+    isError: {
+      control: false,
+      description: '입력 필드 에러 상태 여부 (false로 고정)',
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    size: 'regular',
+    isDisabled: true,
+    isError: false,
+    placeholder: '비활성화된 입력 필드',
+  },
+  argTypes: {
+    isDisabled: {
+      control: false,
+      description: '입력 필드 비활성화 여부 (true로 고정)',
+    },
+    isError: {
+      control: false,
+      description: '입력 필드 에러 상태 여부 (false로 고정)',
+    },
+  },
+};
+
+export const Error: Story = {
+  args: {
+    size: 'regular',
+    isDisabled: false,
+    isError: true,
+    placeholder: '에러 상태 입력 필드',
+  },
+  argTypes: {
+    isDisabled: {
+      control: false,
+      description: '입력 필드 비활성화 여부 (false로 고정)',
+    },
+    isError: {
+      control: false,
+      description: '입력 필드 에러 상태 여부 (true로 고정)',
+    },
+  },
+};


### PR DESCRIPTION
## 📌 이슈 번호

> #9 

## 🚀 상세 설명

- variant: primary
- size: mini, small, regular, large 
- state: default, focus, error, errorFocus, disabled
- placeholder, value
- 스토리북 input 컴포넌트 적용

## 📸 스크린샷
![screencapture-localhost-5173-2025-07-23-15_46_32](https://github.com/user-attachments/assets/6c9b5ad6-1ad4-4569-ba31-f0706a19dbd6)
![screencapture-localhost-5173-2025-07-23-15_46_32 2](https://github.com/user-attachments/assets/5dbd405d-377a-45e2-b9da-0b315441bb97)


## 📢 노트
- 파일, OTP 인풋 추가 구현 예정
