### PR TITLE
feat: Button 컴포넌트 확장(아이콘, 로딩, 링크 버튼 추가)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
+        "lucide-react": "^0.539.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.11"
@@ -4510,6 +4511,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.539.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.539.0.tgz",
+      "integrity": "sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
+    "lucide-react": "^0.539.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.11"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,145 +1,181 @@
-import { useState } from 'react';
-import { Radio } from './components/radio/Radio';
+import { Button } from './components/button/Button';
+import { Download, ChevronRight } from 'lucide-react';
+import './index.css';
 
 export default function App() {
-  const [radioStates, setRadioStates] = useState({
-    radio1: false,
-    radio2: true,
-    radio3: false,
-    radio4: false,
-    radio5: false,
-    radio6: true,
-  });
-
-  const handleRadioChange = (radioId: string) => {
-    setRadioStates((prev) => ({
-      ...prev,
-      [radioId]: !prev[radioId as keyof typeof prev],
-    }));
-  };
-
-  const states = ['default', 'disabled', 'error'] as const;
+  const variants = [
+    'primary',
+    'secondary',
+    'outline',
+    'ghost',
+    'destructive',
+  ] as const;
+  const sizes = ['mini', 'small', 'regular', 'large'] as const;
+  const states = ['default', 'disabled'] as const;
 
   return (
     <div className='w-screen min-h-screen bg-gray-50 p-8'>
-      <div className='max-w-4xl mx-auto'>
+      <div className='max-w-6xl mx-auto'>
         <h1 className='text-3xl font-bold text-center mb-8 text-gray-800'>
-          Radio Design System
+          Button Design System
         </h1>
-        {/* 기본 라디오 버튼들 */}
-        <div className='mb-12'>
-          <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
-            기본 라디오 버튼 (개별)
-          </h2>
-          <div className='bg-white p-8 rounded-lg shadow-sm border'>
-            <div className='grid grid-cols-2 gap-6'>
-              <div className='flex flex-col items-center space-y-3'>
-                <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
-                  라벨 있음
-                </div>
-                <Radio
-                  label='옵션 1'
-                  value='option1'
-                  checked={radioStates.radio1}
-                  onChange={() => handleRadioChange('radio1')}
-                />
-                <div className='text-xs text-gray-400 text-center'>
-                  개별 라디오 / 라벨 있음
-                </div>
-              </div>
-              <div className='flex flex-col items-center space-y-3'>
-                <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
-                  라벨 없음
-                </div>
-                <Radio
-                  value='option2'
-                  checked={radioStates.radio2}
-                  onChange={() => handleRadioChange('radio2')}
-                />
-                <div className='text-xs text-gray-400 text-center'>
-                  개별 라디오 / 라벨 없음
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* 상태별 라디오 */}
-        {states.map((state) => (
-          <div key={state} className='mb-12'>
+        {/* 전체 스타일 */}
+        {variants.map((variant) => (
+          <div key={variant} className='mb-12'>
             <h2 className='text-2xl font-semibold mb-6 text-gray-700 capitalize border-b pb-2'>
-              {state} State
+              {variant} Variant
             </h2>
-            <div className='bg-white p-6 rounded-lg shadow-sm border'>
-              <div className='grid grid-cols-2 gap-6'>
-                <div className='flex flex-col items-center space-y-3'>
-                  <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
-                    라벨 있음
-                  </div>
-                  <Radio
-                    label={`${state} radio`}
-                    value={`${state}-with-label`}
-                    checked={false}
-                    isDisable={state === 'disabled'}
-                    isError={state === 'error'}
-                  />
-                  <div className='text-xs text-gray-400 text-center'>
-                    {state} / 라벨 있음
+            <div className='grid gap-8'>
+              {states.map((state) => (
+                <div
+                  key={state}
+                  className='bg-white p-6 rounded-lg shadow-sm border'
+                >
+                  <h3 className='text-lg font-medium mb-4 text-gray-600 capitalize'>
+                    {state} State
+                  </h3>
+                  <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6'>
+                    {sizes.map((size) => (
+                      <div
+                        key={size}
+                        className='flex flex-col items-center space-y-3'
+                      >
+                        <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
+                          {size}
+                        </div>
+                        <Button
+                          variant={variant}
+                          size={size}
+                          isDisabled={state === 'disabled'}
+                        >
+                          Label
+                        </Button>
+                        <div className='text-xs text-gray-400 text-center'>
+                          {variant} / {size} / {state}
+                        </div>
+                      </div>
+                    ))}
                   </div>
                 </div>
-                <div className='flex flex-col items-center space-y-3'>
-                  <div className='text-sm font-medium text-gray-500 uppercase tracking-wide'>
-                    라벨 없음
-                  </div>
-                  <Radio
-                    value={`${state}-no-label`}
-                    checked={true}
-                    isDisable={state === 'disabled'}
-                    isError={state === 'error'}
-                  />
-                  <div className='text-xs text-gray-400 text-center'>
-                    {state} / 라벨 없음
-                  </div>
-                </div>
-              </div>
+              ))}
             </div>
           </div>
         ))}
-        {/* 라벨 없는 라디오 모음 */}
-        <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
-          라벨 없는 라디오 - 다양한 상태
-        </h2>
-        <div className='flex flex-wrap gap-8 justify-center bg-white  p-6 rounded-lg shadow-sm border'>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio value='no-label-default' checked={false} />
-            <span className='text-xs text-gray-500'>default</span>
+        {/* variant 전체 */}
+        <div className='mt-16 bg-white p-8 rounded-lg shadow-sm border'>
+          <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
+            한눈에 보기 - Regular Size, Default State
+          </h2>
+          <div className='flex flex-wrap gap-4 justify-center'>
+            {variants.map((variant) => (
+              <div
+                key={variant}
+                className='flex flex-col items-center space-y-2'
+              >
+                <Button variant={variant} size='regular' isDisabled={false}>
+                  {variant}
+                </Button>
+                <span className='text-xs text-gray-500 capitalize'>
+                  {variant}
+                </span>
+              </div>
+            ))}
           </div>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio value='no-label-checked' checked={true} />
-            <span className='text-xs text-gray-500'>checked</span>
+        </div>
+        {/* 사이즈 비교 */}
+        <div className='mt-8 bg-white p-8 rounded-lg shadow-sm border'>
+          <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
+            사이즈 비교 - Primary Variant, Default State
+          </h2>
+          <div className='flex flex-wrap items-end gap-6 justify-center'>
+            {sizes.map((size) => (
+              <div key={size} className='flex flex-col items-center space-y-2'>
+                <Button variant='primary' size={size} isDisabled={false}>
+                  {size}
+                </Button>
+                <span className='text-xs text-gray-500 capitalize'>{size}</span>
+              </div>
+            ))}
           </div>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio value='no-label-disabled' checked={false} isDisable={true} />
-            <span className='text-xs text-gray-500'>disabled</span>
+        </div>
+        {/* 상태 비교 */}
+        <div className='mt-8 bg-white p-8 rounded-lg shadow-sm border'>
+          <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
+            상태 비교 - Primary Variant, Regular Size
+          </h2>
+          <div className='flex gap-6 justify-center'>
+            {states.map((state) => (
+              <div key={state} className='flex flex-col items-center space-y-2'>
+                <Button
+                  variant='primary'
+                  size='regular'
+                  isDisabled={state === 'disabled'}
+                >
+                  {state}
+                </Button>
+                <span className='text-xs text-gray-500 capitalize'>
+                  {state}
+                </span>
+              </div>
+            ))}
           </div>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio
-              value='no-label-disabled-checked'
-              checked={true}
-              isDisable={true}
-            />
-            <span className='text-xs text-gray-500'>disabled + checked</span>
-          </div>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio value='no-label-error' checked={false} isError={true} />
-            <span className='text-xs text-gray-500'>error</span>
-          </div>
-          <div className='flex flex-col items-center space-y-2'>
-            <Radio
-              value='no-label-error-checked'
-              checked={true}
-              isError={true}
-            />
-            <span className='text-xs text-gray-500'>error + checked</span>
+        </div>
+        {/* 아이콘이 있는 버튼 */}
+        <div className='mt-8 bg-white p-8 rounded-lg shadow-sm border'>
+          <h2 className='text-2xl font-semibold mb-6 text-gray-700 border-b pb-2'>
+            아이콘이 있는 버튼 - All Variants, Regular Size
+          </h2>
+          <div className='grid gap-8'>
+            <div className='bg-gray-50 p-6 rounded-lg'>
+              <h3 className='text-lg font-medium mb-4 text-gray-600'>
+                아이콘 왼쪽 정렬
+              </h3>
+              <div className='flex flex-wrap gap-4 justify-center'>
+                {variants.map((variant) => (
+                  <div
+                    key={variant}
+                    className='flex flex-col items-center space-y-2'
+                  >
+                    <Button
+                      variant={variant}
+                      size='regular'
+                      icon={<Download />}
+                      iconPosition='left'
+                    >
+                      좋아요
+                    </Button>
+                    <span className='text-xs text-gray-500 capitalize'>
+                      {variant}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className='bg-gray-50 p-6 rounded-lg'>
+              <h3 className='text-lg font-medium mb-4 text-gray-600'>
+                아이콘 오른쪽 정렬
+              </h3>
+              <div className='flex flex-wrap gap-4 justify-center'>
+                {variants.map((variant) => (
+                  <div
+                    key={variant}
+                    className='flex flex-col items-center space-y-2'
+                  >
+                    <Button
+                      variant={variant}
+                      size='regular'
+                      icon={<ChevronRight />}
+                      iconPosition='right'
+                    >
+                      계속하기
+                    </Button>
+                    <span className='text-xs text-gray-500 capitalize'>
+                      {variant}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,9 +1,14 @@
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { cloneElement } from 'react';
+
+type IconElement = ReactElement<{ className?: string }>;
 
 type ButtonProps = {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'destructive';
   size?: 'mini' | 'small' | 'regular' | 'large';
   isDisabled?: boolean;
+  iconPosition?: 'left' | 'right';
+  icon?: IconElement;
   children?: ReactNode;
 };
 
@@ -11,6 +16,8 @@ export const Button = ({
   variant = 'primary',
   size = 'regular',
   isDisabled = false,
+  iconPosition = 'left',
+  icon,
   children,
   ...props
 }: ComponentProps<'button'> & ButtonProps) => {
@@ -35,7 +42,21 @@ export const Button = ({
     disabled: 'opacity-50 cursor-not-allowed',
   };
 
+  const iconSizeClass = {
+    mini: 'w-3.5 h-3.5',
+    small: 'w-4 h-4',
+    regular: 'w-5 h-5',
+    large: 'w-6 h-6',
+  };
+
   const state = isDisabled ? 'disabled' : 'default';
+
+  const renderIcon = () => {
+    if (!icon) return null;
+    return cloneElement(icon, {
+      className: `${iconSizeClass[size]}`.trim(),
+    });
+  };
 
   return (
     <>
@@ -49,7 +70,21 @@ export const Button = ({
         disabled={isDisabled}
         {...props}
       >
-        {children}
+        {icon ? (
+          iconPosition === 'left' ? (
+            <div className='flex justify-center items-center gap-1.5'>
+              {renderIcon()}
+              {children}
+            </div>
+          ) : (
+            <div className='flex justify-center items-center gap-1.5'>
+              {children}
+              {renderIcon()}
+            </div>
+          )
+        ) : (
+          <>{children}</>
+        )}
       </button>
     </>
   );

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from '../components/button/Button';
+import { Download } from 'lucide-react';
 
 const meta = {
   title: 'Components/Button',
@@ -22,6 +23,15 @@ const meta = {
     isDisabled: {
       control: { type: 'boolean' },
       description: '버튼 비활성화 여부',
+    },
+    icon: {
+      control: { type: 'select' },
+      description: 'Lucide 아이콘 컴포넌트',
+    },
+    iconPosition: {
+      control: { type: 'select' },
+      options: ['left', 'right'],
+      description: '아이콘 위치',
     },
     children: {
       control: { type: 'text' },
@@ -68,6 +78,12 @@ export const Primary: Story = {
       control: false,
       description: '버튼의 스타일 변형 (Primary로 고정)',
     },
+    icon: {
+      control: false,
+    },
+    iconPosition: {
+      control: false,
+    },
   },
 };
 
@@ -82,6 +98,12 @@ export const Secondary: Story = {
     variant: {
       control: false,
       description: '버튼의 스타일 변형 (Secondary로 고정)',
+    },
+    icon: {
+      control: false,
+    },
+    iconPosition: {
+      control: false,
     },
   },
 };
@@ -98,6 +120,12 @@ export const Outline: Story = {
       control: false,
       description: '버튼의 스타일 변형 (Outline으로 고정)',
     },
+    icon: {
+      control: false,
+    },
+    iconPosition: {
+      control: false,
+    },
   },
 };
 
@@ -113,6 +141,12 @@ export const Ghost: Story = {
       control: false,
       description: '버튼의 스타일 변형 (Ghost로 고정)',
     },
+    icon: {
+      control: false,
+    },
+    iconPosition: {
+      control: false,
+    },
   },
 };
 
@@ -127,6 +161,28 @@ export const Destructive: Story = {
     variant: {
       control: false,
       description: '버튼의 스타일 변형 (Destructive로 고정)',
+    },
+    icon: {
+      control: false,
+    },
+    iconPosition: {
+      control: false,
+    },
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    variant: 'primary',
+    size: 'regular',
+    isDisabled: false,
+    icon: <Download />,
+    iconPosition: 'left',
+    children: '다운로드',
+  },
+  argTypes: {
+    icon: {
+      description: 'Lucide 아이콘 모두 가능',
     },
   },
 };


### PR DESCRIPTION
## 📌 이슈 번호

> #18 

## 🚀 상세 설명

- Icon Button (아이콘 버튼)
  - Icon + Label 버튼
  - Icon Only 버튼
- Loading Button (로딩 버튼)

## 📸 스크린샷
<img width="1225" height="1116" alt="image" src="https://github.com/user-attachments/assets/4d2ee45a-b2ba-4d23-8de5-67eaed3f8adc" />

## 📢 노트
- **기존 API 호환성 유지**: 기존에 사용 중인 Button은 그대로 동작
- **아이콘 라이브러리**: `lucide-react` 사용